### PR TITLE
crs 10058

### DIFF
--- a/src/ApiConnectors/BrowseDataApiConnector.php
+++ b/src/ApiConnectors/BrowseDataApiConnector.php
@@ -74,6 +74,9 @@ class BrowseDataApiConnector extends BaseApiConnector
         $requestBrowseData = new BrowseData($code, $columns, $sortFields);
 
         $response = $this->sendXmlDocument($requestBrowseData);
+        if (!empty($response->getErrorMessages())) {
+            throw new Exception('Failed to send XmlDocument. Got error messages: ' . implode(', ', $response->getErrorMessages()));
+        }
         return BrowseDataMapper::map($response);
     }
 }


### PR DESCRIPTION
Bij versturen van bepaald document werd niet gechecked of het request wel goed ging, waardoor we php errors kregen.
Nu een check toegevoegd zodat de daadwerkelijke fout in onze logging terecht gaat komen (verwacht ik).
https://aqqo.sirportly.com/staff/tickets/BC-589489